### PR TITLE
ci(docker): Add option `-r` when using `supersetbot` CLI

### DIFF
--- a/.github/actions/setup-supersetbot/action.yml
+++ b/.github/actions/setup-supersetbot/action.yml
@@ -23,7 +23,7 @@ runs:
       if: ${{ inputs.from-npm == 'false' }}
       uses: actions/checkout@v4
       with:
-        repository: apache-superset/supersetbot
+        repository: sid-indonesia/supersetbot
         path: supersetbot
 
     - name: Setup supersetbot from repo

--- a/.github/workflows/bump-python-package.yml
+++ b/.github/workflows/bump-python-package.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/
+        with:
+          from-npm: 'false'
 
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,6 +71,8 @@ jobs:
       - name: Setup supersetbot
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
         uses: ./.github/actions/setup-supersetbot/
+        with:
+          from-npm: 'false'
 
       - name: Build Docker Image
         if: steps.check.outputs.python || steps.check.outputs.frontend || steps.check.outputs.docker
@@ -85,7 +87,7 @@ jobs:
             PLATFORM_ARG="--platform linux/amd64"
           fi
 
-          supersetbot -r summitdeveloper/superset docker \
+          supersetbot docker \
             --preset ${{ matrix.build_preset }} \
             --context "$EVENT" \
             --context-ref "$RELEASE" $FORCE_LATEST \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,7 +85,7 @@ jobs:
             PLATFORM_ARG="--platform linux/amd64"
           fi
 
-          supersetbot docker \
+          supersetbot -r summitdeveloper/superset docker \
             --preset ${{ matrix.build_preset }} \
             --context "$EVENT" \
             --context-ref "$RELEASE" $FORCE_LATEST \

--- a/.github/workflows/issue_creation.yml
+++ b/.github/workflows/issue_creation.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/
+        with:
+          from-npm: 'false'
 
       - name: Execute supersetbot orglabel command
         env:

--- a/.github/workflows/supersetbot.yml
+++ b/.github/workflows/supersetbot.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/
+        with:
+          from-npm: 'false'
 
       - name: Execute custom Node.js script
         env:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -63,6 +63,8 @@ jobs:
 
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/
+        with:
+          from-npm: 'false'
 
       - name: Try to login to DockerHub
         continue-on-error: true
@@ -121,6 +123,8 @@ jobs:
 
       - name: Setup supersetbot
         uses: ./.github/actions/setup-supersetbot/
+        with:
+          from-npm: 'false'
 
       - name: Label the PRs with the right release-related labels
         env:


### PR DESCRIPTION
Resolves https://github.com/sid-indonesia/it-team/issues/348

What this commit has achieved:
1. Forked `apache-superset/supersetbot` into `sid-indonesia/supersetbot`
2. Changed default docker `REPO` from `apache/superset` to `summitdeveloper/superset`
3. Changed source of `supersetbot` installation from the GitHub repo `sid-indonesia/supersetbot`
4. Option `-r` in `supersetbot` default value is `process.env.GITHUB_REPOSITORY`, so no need to explicitly pass the argument `sid-indonesia/superset`

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
